### PR TITLE
Update MovieCard hover styles and button design

### DIFF
--- a/client/components/MovieCard.tsx
+++ b/client/components/MovieCard.tsx
@@ -76,9 +76,9 @@ export function MovieCard({
           <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
           <button
             aria-label="Guardar"
-            className="absolute right-2 top-2 rounded-full bg-black/60 p-2 text-white opacity-0 shadow-sm transition-opacity duration-300 group-hover:opacity-100"
+            className="absolute right-2 top-2 text-white opacity-0 transition-opacity duration-300 group-hover:opacity-100"
           >
-            <Bookmark className="h-4 w-4" />
+            <Bookmark className="w-[22px] h-[28px]" />
           </button>
           <div className="absolute inset-x-3 bottom-3 translate-y-2 space-y-2 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
             <h3 className="line-clamp-2 text-base font-semibold leading-tight text-white drop-shadow-sm">
@@ -93,7 +93,7 @@ export function MovieCard({
               <span className="font-medium">{provider}</span>
             </div>
             <div>
-              <button className="inline-flex items-center gap-2 rounded-full bg-white/90 px-3 py-1.5 text-sm font-semibold text-black shadow-sm backdrop-blur-sm transition-colors hover:bg-white">
+              <button className="inline-flex items-center gap-2 rounded-full bg-[#3c4043] px-3 py-1.5 text-sm font-semibold text-white w-[190px] shadow-sm transition-colors hover:bg-[#3c4043]/90">
                 Mirar en <ChevronDown className="h-4 w-4" />
               </button>
             </div>

--- a/client/components/MovieCard.tsx
+++ b/client/components/MovieCard.tsx
@@ -93,8 +93,9 @@ export function MovieCard({
               <span className="font-medium">{provider}</span>
             </div>
             <div>
-              <button className="inline-flex items-center justify-between rounded-full bg-[#3c4043] px-3 py-1.5 text-sm font-semibold text-white w-[190px] shadow-sm transition-colors hover:bg-[#3c4043]/90">
-                Mirar en <ChevronDown className="h-4 w-4" />
+              <button className="relative inline-flex items-center justify-center rounded-full bg-[#3c4043] px-3 py-1.5 text-sm font-semibold text-white w-[190px] shadow-sm transition-colors hover:bg-[#3c4043]/90">
+                <span className="pointer-events-none">Mirar en</span>
+                <ChevronDown className="h-4 w-4 absolute right-3" />
               </button>
             </div>
           </div>

--- a/client/components/MovieCard.tsx
+++ b/client/components/MovieCard.tsx
@@ -33,9 +33,16 @@ export function MovieCard({
   className,
 }: MovieCardProps) {
   // Normal width to compare against (designer's "ancho normal")
-  const normalWidth = expandedWidth && expandedWidth > 0 ? expandedWidth : width;
-  const baseWidth = typeof collapsedWidth === "number" && collapsedWidth > 0 ? collapsedWidth : Math.round(normalWidth / 3);
-  const finalHoverWidth = typeof hoverWidth === "number" && hoverWidth > 0 ? hoverWidth : Math.round(normalWidth * 2);
+  const normalWidth =
+    expandedWidth && expandedWidth > 0 ? expandedWidth : width;
+  const baseWidth =
+    typeof collapsedWidth === "number" && collapsedWidth > 0
+      ? collapsedWidth
+      : Math.round(normalWidth / 3);
+  const finalHoverWidth =
+    typeof hoverWidth === "number" && hoverWidth > 0
+      ? hoverWidth
+      : Math.round(normalWidth * 2);
 
   return (
     <div
@@ -85,7 +92,9 @@ export function MovieCard({
               {title}
             </h3>
             <div className="flex items-center gap-2 text-xs text-white/90">
-              <span className="rounded border border-white/50 px-1.5 py-0.5 leading-none">{rating}</span>
+              <span className="rounded border border-white/50 px-1.5 py-0.5 leading-none">
+                {rating}
+              </span>
               <span>{duration}</span>
               <span>•</span>
               <span>{year}</span>
@@ -100,7 +109,9 @@ export function MovieCard({
             </div>
           </div>
         </div>
-        <div className="mt-2 truncate text-sm font-medium text-foreground/90">{title}</div>
+        <div className="mt-2 truncate text-sm font-medium text-foreground/90">
+          {title}
+        </div>
       </div>
     </div>
   );

--- a/client/components/MovieCard.tsx
+++ b/client/components/MovieCard.tsx
@@ -93,7 +93,7 @@ export function MovieCard({
               <span className="font-medium">{provider}</span>
             </div>
             <div>
-              <button className="inline-flex items-center gap-2 rounded-full bg-[#3c4043] px-3 py-1.5 text-sm font-semibold text-white w-[190px] shadow-sm transition-colors hover:bg-[#3c4043]/90">
+              <button className="inline-flex items-center justify-between rounded-full bg-[#3c4043] px-3 py-1.5 text-sm font-semibold text-white w-[190px] shadow-sm transition-colors hover:bg-[#3c4043]/90">
                 Mirar en <ChevronDown className="h-4 w-4" />
               </button>
             </div>


### PR DESCRIPTION
## Purpose

The user wanted to improve the MovieCard component's hover interaction by:
- Removing the black circle background from the bookmark icon on hover
- Resizing the bookmark icon to specific dimensions (22px width, 28px height)
- Redesigning the "Mirar en" button with white text, dark background (#3c4043), and fixed width (190px)
- Positioning the dropdown arrow icon in the right corner of the button
- Centering the "Mirar en" text within the button

## Code changes

- **Bookmark button**: Removed `rounded-full bg-black/60 p-2` classes and `shadow-sm`, keeping only positioning and opacity transitions
- **Bookmark icon**: Updated size from `h-4 w-4` to `w-[22px] h-[28px]`
- **"Mirar en" button**: 
  - Changed background from `bg-white/90` to `bg-[#3c4043]`
  - Changed text color from `text-black` to `text-white`
  - Added fixed width `w-[190px]` and `justify-center` for centering
  - Made button `relative` positioned
- **Dropdown arrow**: Positioned absolutely with `absolute right-3` within the button
- **Button text**: Wrapped in span with `pointer-events-none` for better interaction
- **Code formatting**: Improved readability by breaking long ternary operations into multiple linesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a7f4f5e1b3144d18b2eeff1a434a95a0/zen-works)

👀 [Preview Link](https://a7f4f5e1b3144d18b2eeff1a434a95a0-zen-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a7f4f5e1b3144d18b2eeff1a434a95a0</projectId>-->
<!--<branchName>zen-works</branchName>-->